### PR TITLE
Fixed file permissions for Linux

### DIFF
--- a/tasks/closure-compiler-build.js
+++ b/tasks/closure-compiler-build.js
@@ -11,7 +11,7 @@ module.exports = function (grunt) {
 			done = this.async(),
 			file;
 
-		fs.mkdirSync(build.dir, 777, true, function (err) {
+		fs.mkdirSync(build.dir, '0777', true, function (err) {
 			if (err && err.code != 'EEXIST') {
 				grunt.warn('ERROR[' + err.errno + ']: ' + err.message);
 				return false;


### PR DESCRIPTION
In Linux, mode Octal 777 means all rights for everyone. But in JavaScript, 777 is decimal, which translates to Octal 1411. This results in a directory that the user cannot act against. Fortunately, mkdirSync allows for the octal to be passed in as a string. Changing 777 to '0777' creates the build directory correctly.
